### PR TITLE
Remove implied recipe dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ A content block to embed media from other websites via oEmbed
 
 ## Requirements
 
-* silverstripe/recipe-cms: ^4@dev
 * dnadesign/silverstripe-elemental: ^4@dev
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "dnadesign/silverstripe-elemental": "^4@dev",
-        "sheadawson/silverstripe-linkable": "^2@dev",
-        "silverstripe/recipe-cms": "^4@dev",
-        "silverstripe/vendor-plugin": "^1@dev"
+        "sheadawson/silverstripe-linkable": "^2@dev"
     },
     "require-dev": {
         "phpunit/PHPUnit": "^5.7",


### PR DESCRIPTION
First of all: Great work on building out the elemental block ecosystem 🎉 

Technically the module isn't dependant on the whole recipe,
it just inherits some dependencies from the elemental module.

Declaring dependence on the recipe is problematic,
for example it forces you into installing silverstripe/errorpage
even though it's not required for this module.

If you want to guard against e.g. elemental declaring a wider
range of core dependencies than this module, you could specifically
narrow down the range on silverstripe/framework, silverstripe/cms, etc

The vendor-plugin dependency is also implied through core.