### PR TITLE
Add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [dynamic]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Silverstripe Elemental Media Block
 
+[![Sponsors](https://img.shields.io/badge/Sponsor-Dynamic-ff69b4?logo=github-sponsors&logoColor=white)](https://github.com/sponsors/dynamic)
+
 A content block to embed media from other websites via oEmbed
 
 [![CI](https://github.com/dynamic/silverstripe-elemental-oembed/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamic/silverstripe-elemental-oembed/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # Silverstripe Elemental Media Block
 
-[![Sponsors](https://img.shields.io/badge/Sponsor-Dynamic-ff69b4?logo=github-sponsors&logoColor=white)](https://github.com/sponsors/dynamic)
-
 A content block to embed media from other websites via oEmbed
 
 [![CI](https://github.com/dynamic/silverstripe-elemental-oembed/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamic/silverstripe-elemental-oembed/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/dynamic/silverstripe-elemental-oembed/branch/master/graph/badge.svg)](https://codecov.io/gh/dynamic/silverstripe-elemental-oembed)
+[![Sponsors](https://img.shields.io/badge/Sponsor-Dynamic-ff69b4?logo=github-sponsors&logoColor=white)](https://github.com/sponsors/dynamic)
 
 [![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-elemental-oembed/v/stable)](https://packagist.org/packages/dynamic/silverstripe-elemental-oembed)
 [![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-elemental-oembed/downloads)](https://packagist.org/packages/dynamic/silverstripe-elemental-oembed)

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,12 @@
             "homepage": "http://www.dynamicagency.com"
         }
     ],
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/dynamic"
+        }
+    ],
     "require": {
         "dnadesign/silverstripe-elemental": "^5.0",
         "nathancox/embedfield": "^3.0",


### PR DESCRIPTION
This PR adds GitHub Sponsors support to make it easier for users to support our open source work.

## Changes
- Added `.github/FUNDING.yml` to enable the GitHub Sponsors button in the repository header
- Added GitHub Sponsors badge to README for better visibility
- Points to [@dynamic](https://github.com/sponsors/dynamic) organization sponsors page

## Benefits
- Provides multiple touchpoints for GitHub Sponsors visibility
- Makes it easier for users to support the project
- Aligns with other Dynamic repositories

The badge will appear at the top of the README alongside existing CI/quality badges.