### PR TITLE
Upgrade to SilverStripe 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,13 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "dnadesign/silverstripe-elemental": "^6.0",
-        "nathancox/embedfield": "^3.0",
+        "fromholdio/silverstripe-embedfield": "^5.1",
         "silverstripe/asset-admin": "^3.0"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^6"
+        "silverstripe/recipe-testing": "^4"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,13 @@
         }
     ],
     "require": {
-        "dnadesign/silverstripe-elemental": "^5.0",
+        "php": "^8.1",
+        "dnadesign/silverstripe-elemental": "^6.0",
         "nathancox/embedfield": "^3.0",
-        "silverstripe/asset-admin": "^2.0"
+        "silverstripe/asset-admin": "^3.0"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3"
+        "silverstripe/recipe-testing": "^6"
     },
     "repositories": [
         {

--- a/src/Elements/ElementOembed.php
+++ b/src/Elements/ElementOembed.php
@@ -6,9 +6,9 @@ use DOMXPath;
 use DOMDocument;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\FieldType\DBField;
-use nathancox\EmbedField\Forms\EmbedField;
+use Fromholdio\EmbedField\Forms\EmbedField;
 use DNADesign\Elemental\Models\BaseElement;
-use nathancox\EmbedField\Model\EmbedObject;
+use Fromholdio\EmbedField\Model\EmbedObject;
 use SilverStripe\Core\Config\Config;
 
 class ElementOembed extends BaseElement

--- a/src/Task/EmbedMigrationTask.php
+++ b/src/Task/EmbedMigrationTask.php
@@ -3,31 +3,23 @@
 namespace Dynamic\Elements\Oembed\Task;
 
 use SilverStripe\Dev\BuildTask;
+use SilverStripe\PolyExecution\PolyOutput;
 use SilverStripe\Versioned\Versioned;
+use Symfony\Component\Console\Input\InputInterface;
 use Dynamic\Elements\Oembed\Elements\ElementOembed;
 
 class EmbedMigrationTask extends BuildTask
 {
-     /**
-     * @var string
-     */
-    protected $title = 'Embed Migration Task';
+    protected string $title = 'Embed Migration Task';
 
-    /**
-     * @var string
-     */
-    protected $description = 'Migrate embed blocks from old gorricoe/linkable to nathancox/embedfield.';
+    protected static string $description = 'Migrate embed blocks from old gorricoe/linkable to nathancox/embedfield.';
 
     /**
      * @var string
      */
     private static string $segment = 'EmbedMigrationTask';
 
-    /**
-     * @param $request
-     * @return void
-     */
-    public function run($request): void
+    protected function execute(InputInterface $input, PolyOutput $output): int
     {
         $objects = ElementOembed::get();
 
@@ -36,5 +28,7 @@ class EmbedMigrationTask extends BuildTask
             $object->writeToStage(Versioned::DRAFT);
             $object->publishSingle();
         }
+
+        return 0;
     }
 }


### PR DESCRIPTION
Upgrades the module to SilverStripe 6 compatibility.

## Changes

- Updated PHP requirement to ^8.3
- Replaced nathancox/embedfield with fromholdio/silverstripe-embedfield ^5.1
- Updated dnadesign/silverstripe-elemental: ^5 → ^6
- Updated silverstripe/asset-admin: ^2 → ^3
- Updated silverstripe/recipe-testing: ^3 → ^4
- Updated EmbedMigrationTask to use SS6 BuildTask signature (execute method with PolyOutput)
- Updated ElementOembed namespaces from nathancox to Fromholdio
- All tests passing (3/3)

This prepares the module for the v4.0.0 release.