### PR TITLE
Fix composer: alias htmltag as dev-master to resolve dependency conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "dnadesign/silverstripe-elemental": "^5.0",
         "dnadesign/silverstripe-embed": "dev-master",
-        "gorriecoe/silverstripe-htmltag": "dev-bugfix/depreciations as 1.1.0",
+        "gorriecoe/silverstripe-htmltag": "dev-bugfix/depreciations as dev-master",
         "silverstripe/asset-admin": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary

Fixes composer dependency conflict by changing the `gorriecoe/silverstripe-htmltag` alias from `1.1.0` to `dev-master`.

## Problem

CI was failing with:
```
Your requirements could not be resolved to an installable set of packages.

Problem 1
  - Root composer.json requires dnadesign/silverstripe-embed dev-master -> satisfiable by dnadesign/silverstripe-embed[dev-master].
  - dnadesign/silverstripe-embed dev-master requires gorriecoe/silverstripe-htmltag dev-master -> found gorriecoe/silverstripe-htmltag[dev-master] but it conflicts with your root composer.json require (dev-bugfix/depreciations as 1.1.0).
```

## Solution

Changed the alias from `as 1.1.0` to `as dev-master` so that the fork branch satisfies the `dev-master` requirement from `dnadesign/silverstripe-embed`.