### PR TITLE
REFACTOR: Remove getType() override to allow extensibility

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -5,5 +5,5 @@ en:
     PLURALS:
       one: 'A Media Element'
       other: '{count} Media Elements'
-    SINGULARNAME: Media Element
+    SINGULARNAME: Media
     EmbeddedObjectLabel: Content from oEmbed URL

--- a/src/Elements/ElementOembed.php
+++ b/src/Elements/ElementOembed.php
@@ -16,6 +16,16 @@ class ElementOembed extends BaseElement
     /**
      * @var string
      */
+    private static $singular_name = 'Media';
+
+    /**
+     * @var string
+     */
+    private static $plural_name = 'Media Elements';
+
+    /**
+     * @var string
+     */
     private static $icon = 'font-icon-block-media';
 
     /**
@@ -161,14 +171,6 @@ class ElementOembed extends BaseElement
         $blockSchema = parent::provideBlockSchema();
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Media');
     }
 
     /**


### PR DESCRIPTION
## Summary

Remove the `getType()` method override so the element inherits `BaseElement::getType()` which uses `i18n_singular_name()`. This allows sites to customize the element's display name via extensions by setting `$singular_name`.

## Changes

- Removed the `getType()` method from `ElementOembed`
- Added `$singular_name = 'Media'`
- Added `$plural_name = 'Media Blocks'`

## Rationale

The base `BaseElement::getType()` implementation already uses `$this->i18n_singular_name()`:

```php
public function getType()
{
    $default = $this->i18n_singular_name() ?: 'Block';
    return _t(static::class . '.BlockType', $default);
}
```

By removing the override and setting `$singular_name`, extensions can now customize the display name in the CMS element picker by simply setting `$singular_name`, without needing to override the entire method.

Fixes #32

Related: dynamic/silverstripe-essentials-tools#68