### PR TITLE
fix(#38): remove getType() override, add singular/plural names

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -5,5 +5,5 @@ en:
     PLURALS:
       one: 'A Media Element'
       other: '{count} Media Elements'
-    SINGULARNAME: Media Element
+    SINGULARNAME: Media
     EmbeddedObjectLabel: Content from oEmbed URL

--- a/src/Elements/ElementOembed.php
+++ b/src/Elements/ElementOembed.php
@@ -16,6 +16,16 @@ class ElementOembed extends BaseElement
     /**
      * @var string
      */
+    private static $singular_name = 'Media';
+
+    /**
+     * @var string
+     */
+    private static $plural_name = 'Media Elements';
+
+    /**
+     * @var string
+     */
     private static $icon = 'font-icon-block-media';
 
     /**
@@ -161,14 +171,6 @@ class ElementOembed extends BaseElement
         $blockSchema = parent::provideBlockSchema();
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Media');
     }
 
     /**


### PR DESCRIPTION
## Summary

- Remove deprecated `getType()` override (SS6 removes `BaseElement::getDescription()`/`getType()` path)
- Add `$singular_name = 'Media'` and `$plural_name = 'Media Elements'` static config properties
- Update `lang/en.yml` SINGULARNAME from `'Media Element'` to `'Media'`

Closes #38

## Test plan

- [ ] `ddev sake dev/build flush=1` exits 0 with "Database build completed!"
- [ ] CI passes (phplinting, phpunit)