### PR TITLE
fix(#41): remove dead htmltag VCS repository, fix stale task description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,6 @@
     "require-dev": {
         "silverstripe/recipe-testing": "^4"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "git@github.com:jsirish/silverstripe-htmltag.git"
-        }
-    ],
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {

--- a/src/Task/EmbedMigrationTask.php
+++ b/src/Task/EmbedMigrationTask.php
@@ -12,7 +12,7 @@ class EmbedMigrationTask extends BuildTask
 {
     protected string $title = 'Embed Migration Task';
 
-    protected static string $description = 'Migrate embed blocks from old gorricoe/linkable to nathancox/embedfield.';
+    protected static string $description = 'Migrate embed blocks to fromholdio/silverstripe-embedfield.';
 
     /**
      * @var string


### PR DESCRIPTION
## Summary
- Removes the `repositories` VCS entry for `jsirish/silverstripe-htmltag` — a leftover from the pre-SS6 `nathancox/embedfield` dependency chain, dead since the swap to `fromholdio/silverstripe-embedfield ^5.1`.
- Fixes `EmbedMigrationTask`'s stale `$description` (typo'd `gorricoe/linkable`, wrong target package `nathancox/embedfield`).

Closes #41

Found while auditing the suite after `dnadesign/silverstripe-embed` 2.0.0's release, to confirm no elemental module needed updating onto it (none do).

## Test plan
- [x] Confirmed no code references `gorriecoe`/`htmltag` anywhere in this module
- [ ] `ddev sake dev/build flush=1` in the essentials-ss6 testbed
- [ ] `ddev exec vendor/bin/phpcs vendor/dynamic/silverstripe-elemental-oembed/src`
- [ ] Front-end render check of a page with an ElementOembed block